### PR TITLE
fix: add packageManager and repository fields to package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Minimal npm package template with automated releases via OIDC trusted publishing
 ## New Package Setup
 
 1. **Create repo from template** on GitHub
-2. **Update `package.json`** — set `name`, `description`, `repository`, `bugs`, `homepage`
+2. **Update `package.json`** — set `name`, `description`, `repository.url`, `bugs.url`, `homepage`, and `packageManager` (if using a different pnpm version)
 3. **Run `pnpm install`**
 4. **Run `pnpm bootstrap` manually in your terminal** — registers the package on npm using your local auth. This must be run interactively (not from a script or CI) because npm requires 2FA/OTP confirmation.
 5. **Configure trusted publisher** in npm UI:

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/0xtiby/basic-package-template.git"
+    "url": "https://github.com/0xtiby/basic-package-template.git"
   },
   "keywords": [],
   "author": "0xtiby <https://github.com/0xtiby>",


### PR DESCRIPTION
## Summary

- Remove `git+` prefix from `repository.url` so it matches the format expected by npm OIDC provenance verification during publish
- Update README setup instructions to explicitly mention `repository.url`, `bugs.url`, and `packageManager` fields that need updating after creating from template

Closes #12
Closes #13

## Test plan

- [ ] Verify `pnpm/action-setup@v4` picks up `packageManager` field in CI
- [ ] Verify `npm publish --provenance` succeeds with the updated `repository.url` format