### PR TITLE
fix: normalize repository URL and close package.json template issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/0xtiby/basic-package-template.git"
+    "url": "https://github.com/0xtiby/basic-package-template.git"
   },
   "keywords": [],
   "author": "0xtiby <https://github.com/0xtiby>",


### PR DESCRIPTION
## Summary

- Normalizes `repository.url` in `package.json` by removing the `git+` prefix so it matches the format npm expects when verifying OIDC provenance bundles (fixes the 422 error described in #13)
- Both `packageManager` (pnpm@9.15.4) and `repository` fields were already present — this PR fixes the URL format for provenance compatibility

Closes #12
Closes #13

## Test plan

- [ ] Verify `pnpm/action-setup@v4` still detects pnpm version from `packageManager` field
- [ ] Verify npm provenance verification passes with the normalized `repository.url`